### PR TITLE
🐛 Fix the issue After the prompt fine-tuning button is clicked, the user instruction is not displayed. #201

### DIFF
--- a/frontend/app/setup/agentSetup/components/AdditionalRequestInput.tsx
+++ b/frontend/app/setup/agentSetup/components/AdditionalRequestInput.tsx
@@ -15,10 +15,13 @@ export interface AdditionalRequestInputProps {
 export default function AdditionalRequestInput({ onSend, isTuning = false }: AdditionalRequestInputProps) {
   const [request, setRequest] = useState("")
   
-  const handleSend = () => {
+  const handleSend = async () => {
     if (request.trim()) {
-      onSend(request)
-      setRequest("")
+      try {
+        await onSend(request)
+      } catch (error) {
+        console.error("微调指令发送失败:", error)
+      }
     }
   }
   


### PR DESCRIPTION
After the prompt fine-tuning button is clicked, the user instruction is not displayed. #201
1.Optimized the user experience, when you click to send a fine-tuning command, the fine-tuning command will not be cleared.

Before:
![image](https://github.com/user-attachments/assets/0e2b51a0-8f31-4ef4-b043-bc58e09e7733)

Current:
![image](https://github.com/user-attachments/assets/68ee41e4-37a0-4659-9264-265b3dd6827e)
