### PR TITLE
🐛 Fix the issue where "background-free images display with a black background, making the top-right close button difficult to see" #157

### DIFF
--- a/frontend/app/chat/internal/chatInterface.tsx
+++ b/frontend/app/chat/internal/chatInterface.tsx
@@ -38,6 +38,8 @@ import { ChatMessageType, AgentStep } from '@/types/chat'
 import { handleStreamResponse } from "@/app/chat/streaming/chatStreamHandler"
 import { extractUserMsgFromResponse, extractAssistantMsgFromResponse } from "./extractMsgFromHistoryResponse"
 
+import { X } from "lucide-react"
+
 const stepIdCounter = {current: 0};
 
 export function ChatInterface() {
@@ -920,23 +922,29 @@ export function ChatInterface() {
         </Tooltip>
       </TooltipProvider>
 
-      {/* 图片预览对话框 */}
+      {/* 图片预览 */}
       {viewingImage && (
-        <Dialog open={!!viewingImage} onOpenChange={(open) => !open && setViewingImage(null)}>
-          <DialogContent className="max-w-4xl p-0 overflow-hidden bg-black/90">
-            <DialogHeader>
-              <DialogTitle className="sr-only">图片预览</DialogTitle>
-            </DialogHeader>
-            <div className="flex items-center justify-center h-full">
-              <img
-                src={viewingImage}
-                alt="图片预览"
-                className="max-h-[80vh] max-w-full"
-                onError={() => handleImageError(viewingImage)}
-              />
-            </div>
-          </DialogContent>
-        </Dialog>
+        <div
+          className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50"
+          onClick={() => setViewingImage(null)}
+        >
+          <div className="relative max-w-[90%] max-h-[90%]" onClick={e => e.stopPropagation()}>
+            <img
+              src={viewingImage}
+              alt="图片预览"
+              className="max-w-full max-h-[90vh] object-contain"
+              onError={() => {
+                handleImageError(viewingImage);
+              }}
+            />
+            <button
+              onClick={() => setViewingImage(null)}
+              className="absolute -top-4 -right-4 bg-white p-1 rounded-full shadow-md hover:bg-white transition-colors"
+            >
+              <X size={16} className="text-gray-600 hover:text-red-500 transition-colors" />
+            </button>
+          </div>
+        </div>
       )}
     </>
   )

--- a/frontend/app/chat/internal/chatInterface.tsx
+++ b/frontend/app/chat/internal/chatInterface.tsx
@@ -922,7 +922,7 @@ export function ChatInterface() {
         </Tooltip>
       </TooltipProvider>
 
-      {/* 图片预览 */}
+      {/* Image preview */}
       {viewingImage && (
         <div
           className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50"


### PR DESCRIPTION
#157
Modify the image preview style in chat messages to match the style used in the chat input box (chatInput.tsx)

 **Image preview rendering in current chat session：**
![img_v3_02mu_9b87dc6c-1a37-4d46-9eb3-23cca762a8dg](https://github.com/user-attachments/assets/d6cdda8a-c98a-4b78-a4ab-382abc7a8361)


**Background-free image preview effect in chat history：**
![img_v3_02mu_9f349e33-abac-4853-b891-6198910ba5bg](https://github.com/user-attachments/assets/40e6bf2b-94df-49ee-968c-ada40d69a5c2)

**Image preview rendering in input box：**
![img_v3_02mu_0a79320b-7f09-4f01-a1b3-c2a9ceac806g](https://github.com/user-attachments/assets/70cca668-a26f-4054-b1ae-9f22d823af8e)
