### PR TITLE
🐛 Bugfix: History source cards are displayed repeatedly #106

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -71,7 +71,7 @@ async def create_tool_config_list(agent_id, tenant_id, user_id):
 
         # special logic for knowledge base search tool
         if tool_config.class_name == "KnowledgeBaseSearchTool":
-            tool_config.metadata = {"index_names": json.loads(config_manager.get_config("SELECTED_KB_NAMES", []))}
+            tool_config.metadata = {"index_names": json.loads(config_manager.get_config("SELECTED_KB_NAMES", "[]"))}
         tool_config_list.append(tool_config)
     return tool_config_list
 

--- a/backend/database/conversation_db.py
+++ b/backend/database/conversation_db.py
@@ -119,7 +119,7 @@ def create_conversation_message(message_data: Dict[str, Any], user_id: Optional[
 
 
 def create_message_units(message_units: List[Dict[str, Any]], message_id: int, conversation_id: int,
-                         user_id: Optional[str] = None) -> bool:
+                         user_id: Optional[str] = None) -> List[int]:
     """
     Batch create message unit records
 
@@ -132,17 +132,18 @@ def create_message_units(message_units: List[Dict[str, Any]], message_id: int, c
         user_id: Reserved parameter for created_by and updated_by fields
 
     Returns:
-        bool: Whether the operation was successful
+        List[int]: List of newly created unit IDs
     """
     if not message_units:
-        return True  # No message units, considered successful
+        return []  # No message units, return empty list
 
     with get_db_session() as session:
         # Ensure IDs are integer type
         message_id = int(message_id)
         conversation_id = int(conversation_id)
 
-        data_list = []
+        # Create units one by one to get unit_ids
+        unit_ids = []
         for idx, unit in enumerate(message_units):
             # Basic data
             row_data = {
@@ -153,12 +154,14 @@ def create_message_units(message_units: List[Dict[str, Any]], message_id: int, c
                 "unit_content": unit['content'],
                 "delete_flag": 'N'
             }
-            data_list.append(row_data)
+            
+            # Insert and get unit_id
+            stmt = insert(ConversationMessageUnit).values(**row_data).returning(ConversationMessageUnit.unit_id)
+            result = session.execute(stmt)
+            unit_id = result.scalar_one()
+            unit_ids.append(unit_id)
 
-        # insert into conversation_message_unit_t
-        stmt = insert(ConversationMessageUnit).values(data_list)
-        session.execute(stmt)
-        return True
+        return unit_ids
 
 
 def get_conversation(conversation_id: int, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
@@ -445,8 +448,9 @@ def get_conversation_history(conversation_id: int, user_id: Optional[str] = None
             # Move the order_by to the json_agg function
             func.json_agg(
                 func.json_build_object(
-                    'type', ConversationMessageUnit.unit_type,
-                    'content', ConversationMessageUnit.unit_content
+                    'unit_id', ConversationMessageUnit.unit_id,
+                    'unit_type', ConversationMessageUnit.unit_type,
+                    'unit_content', ConversationMessageUnit.unit_content
                 )
             )
         ).select_from(
@@ -476,7 +480,7 @@ def get_conversation_history(conversation_id: int, user_id: Optional[str] = None
         search_stmt = select(ConversationSourceSearch).where(
             ConversationSourceSearch.conversation_id == conversation_id,
             ConversationSourceSearch.delete_flag == 'N'
-        )
+        ).order_by(ConversationSourceSearch.search_id)
         search_records = session.scalars(search_stmt).all()
 
         # Get image data
@@ -666,6 +670,7 @@ def create_source_search(search_data: Dict[str, Any], user_id: Optional[str] = N
             - search_type: Source tool
             - tool_sign: Source tool simple identifier, used for summary differentiation
             Optional fields:
+            - unit_id: Message unit ID (integer) 
             - score_overall: Overall relevance score
             - score_accuracy: Accuracy score
             - score_semantic: Semantic relevance score
@@ -693,6 +698,10 @@ def create_source_search(search_data: Dict[str, Any], user_id: Optional[str] = N
             "delete_flag": 'N',
             "create_time": func.current_timestamp()  # Use the database's CURRENT_TIMESTAMP function
         }
+
+        # Add unit_id if provided
+        if 'unit_id' in search_data and search_data['unit_id'] is not None:
+            data["unit_id"] = int(search_data['unit_id'])
 
         # Add optional fields
         if 'score_overall' in search_data:

--- a/frontend/app/chat/layout/chatRightPanel.tsx
+++ b/frontend/app/chat/layout/chatRightPanel.tsx
@@ -148,8 +148,8 @@ export function ChatRightPanel({
     // Process search results
     if (currentMessage?.searchResults && Array.isArray(currentMessage.searchResults)) {
       try {
-        const results = currentMessage.searchResults.map(result => {
-          return {
+        const results = currentMessage.searchResults.map((result, index) => {
+          const processed = {
             title: result.title || "未知标题",
             url: result.url || "#",
             text: result.text || "无内容描述",
@@ -160,7 +160,10 @@ export function ChatRightPanel({
             score_details: result.score_details || {},
             isExpanded: false
           };
+          
+          return processed;
         });
+        
         setSearchResults(results);
       } catch (error) {
         console.error("处理搜索结果时出错:", error);

--- a/frontend/app/chat/streaming/chatStreamHandler.tsx
+++ b/frontend/app/chat/streaming/chatStreamHandler.tsx
@@ -168,6 +168,10 @@ export const handleStreamResponse = async (
                         url: item.url || "#",
                         text: item.text || "无内容描述",
                         published_date: item.published_date || "",
+                        source_type: item.source_type || "",
+                        filename: item.filename || "",
+                        score: typeof item.score === 'number' ? item.score : undefined,
+                        score_details: item.score_details || {},
                         tool_sign: item.tool_sign || "",
                         cite_index: typeof item.cite_index === 'number' ? item.cite_index : -1
                       }));

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -160,6 +160,7 @@ export interface ApiMessage {
   opinion_flag?: string
   picture?: string[]
   search?: SearchResultItem[]
+  search_unit_id?: { [unitId: string]: SearchResultItem[] }
   minio_files?: MinioFileItem[]
   cards?: any[]
 }


### PR DESCRIPTION
1、来源卡片分对话轮次隔离开，每个轮次分开显示
![image](https://github.com/user-attachments/assets/84b7bd8d-43e5-43ce-81ff-d11256338ee7)

2、去重思维过程中的重复块
![image](https://github.com/user-attachments/assets/02678e80-f0a6-436b-a81c-bd3e6fa5ce07)

3、解决搜索来源重叠显示问题
![image](https://github.com/user-attachments/assets/410d9ebe-d6c3-4df7-844b-8f55898b24af)

![image](https://github.com/user-attachments/assets/dcfc5ffb-7b52-4a6b-850b-dff60df81eeb)
使用了unit_id识别来源卡片在message中的位置以保证不会重复

4、先去除内部块的链接
![image](https://github.com/user-attachments/assets/d8ef32a1-8b30-45be-8d6b-83828773166c)

5、增加知识块来源index
![image](https://github.com/user-attachments/assets/dcfc5ffb-7b52-4a6b-850b-dff60df81eeb)
